### PR TITLE
voicevox-ortとして開発する

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Check fmt
         run: cargo fmt --all -- --check
       - name: Run clippy
-        run: cargo clippy -p ort --all-targets --workspace --features fetch-models
+        run: cargo clippy -p voicevox-ort --all-targets --workspace --features fetch-models
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
         run: cargo install cargo-tarpaulin --version 0.28.0
       - name: Generate code coverage
         run: |
-          cargo tarpaulin -p ort --features fetch-models --verbose --timeout 120 --out xml --engine llvm --doc --lib --tests
+          cargo tarpaulin -p voicevox-ort --features fetch-models --verbose --timeout 120 --out xml --engine llvm --doc --lib --tests
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -51,7 +51,7 @@ jobs:
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: false # カバレッジはpykeio/ortに任せる
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          # exclude doctests on Windows
+          # ONNX Runtimeの静的リンクをやめているため、Windowsではdoctestを無効化する
           [ "$RUNNER_OS" = Windows ] && targets=--tests || targets=
           cargo test -p voicevox-ort --verbose --features fetch-models "$targets" -- --test-threads 1
           # Test examples that use in-tree graphs (do NOT run any of the examples that download ~700 MB graphs from pyke parcel...)
@@ -55,7 +55,7 @@ jobs:
   test-wasm:
     name: Test WebAssembly
     runs-on: ubuntu-latest
-    if: false # we don't support WASM yet
+    if: false # WASM版はまだ提供しないため、テストもしない
     steps:
       - uses: actions/checkout@v4
       - name: Install nightly Rust toolchain

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,13 +45,17 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - name: Run tests
+        shell: bash
         run: |
-          cargo test -p ort --verbose --features fetch-models -- --test-threads 1
+          # exclude doctests on Windows
+          [ "$RUNNER_OS" = Windows ] && targets=--tests || targets=
+          cargo test -p voicevox-ort --verbose --features fetch-models "$targets" -- --test-threads 1
           # Test examples that use in-tree graphs (do NOT run any of the examples that download ~700 MB graphs from pyke parcel...)
           cargo run --example custom-ops
   test-wasm:
     name: Test WebAssembly
     runs-on: ubuntu-latest
+    if: false # we don't support WASM yet
     steps:
       - uses: actions/checkout@v4
       - name: Install nightly Rust toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ default-members = [
 exclude = [ 'examples/cudarc' ]
 
 [package]
-name = "ort"
+name = "voicevox-ort"
 description = "A safe Rust wrapper for ONNX Runtime 1.17 - Optimize and Accelerate Machine Learning Inferencing"
 version = "2.0.0-rc.2"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/pykeio/ort"
+repository = "https://github.com/VOICEVOX/ort"
 documentation = "https://ort.pyke.io/"
 readme = "README.md"
 keywords = [ "machine-learning", "ai", "ml" ]
@@ -49,38 +49,41 @@ features = [ "ndarray", "half", "operator-libraries", "fetch-models", "load-dyna
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 rustdoc-args = [ "--cfg", "docsrs" ]
 
+[lib]
+name = "ort"
+
 [features]
 default = [ "ndarray", "half", "download-binaries", "copy-dylibs" ]
 
 operator-libraries = [ "libc", "winapi" ]
 
 fetch-models = [ "ureq" ]
-download-binaries = [ "ort-sys/download-binaries" ]
-load-dynamic = [ "libloading", "ort-sys/load-dynamic" ]
-copy-dylibs = [ "ort-sys/copy-dylibs" ]
+download-binaries = [ "voicevox-ort-sys/download-binaries" ]
+load-dynamic = [ "libloading", "voicevox-ort-sys/load-dynamic" ]
+copy-dylibs = [ "voicevox-ort-sys/copy-dylibs" ]
 
-cuda = [ "ort-sys/cuda" ]
-tensorrt = [ "ort-sys/tensorrt" ]
-openvino = [ "ort-sys/openvino" ]
-onednn = [ "ort-sys/onednn" ]
-directml = [ "ort-sys/directml" ]
-nnapi = [ "ort-sys/nnapi" ]
-coreml = [ "ort-sys/coreml" ]
-xnnpack = [ "ort-sys/xnnpack" ]
-rocm = [ "ort-sys/rocm" ]
-acl = [ "ort-sys/acl" ]
-armnn = [ "ort-sys/armnn" ]
-tvm = [ "ort-sys/tvm" ]
-migraphx = [ "ort-sys/migraphx" ]
-rknpu = [ "ort-sys/rknpu" ]
-vitis = [ "ort-sys/vitis" ]
-cann = [ "ort-sys/cann" ]
-qnn = [ "ort-sys/qnn" ]
+cuda = [ "voicevox-ort-sys/cuda" ]
+tensorrt = [ "voicevox-ort-sys/tensorrt" ]
+openvino = [ "voicevox-ort-sys/openvino" ]
+onednn = [ "voicevox-ort-sys/onednn" ]
+directml = [ "voicevox-ort-sys/directml" ]
+nnapi = [ "voicevox-ort-sys/nnapi" ]
+coreml = [ "voicevox-ort-sys/coreml" ]
+xnnpack = [ "voicevox-ort-sys/xnnpack" ]
+rocm = [ "voicevox-ort-sys/rocm" ]
+acl = [ "voicevox-ort-sys/acl" ]
+armnn = [ "voicevox-ort-sys/armnn" ]
+tvm = [ "voicevox-ort-sys/tvm" ]
+migraphx = [ "voicevox-ort-sys/migraphx" ]
+rknpu = [ "voicevox-ort-sys/rknpu" ]
+vitis = [ "voicevox-ort-sys/vitis" ]
+cann = [ "voicevox-ort-sys/cann" ]
+qnn = [ "voicevox-ort-sys/qnn" ]
 
 [dependencies]
 ndarray = { version = "0.15", optional = true }
 thiserror = "1.0"
-ort-sys = { version = "2.0.0-rc.2", path = "ort-sys" }
+voicevox-ort-sys = { version = "2.0.0-rc.2", path = "ort-sys" }
 libloading = { version = "0.8", optional = true }
 
 ureq = { version = "2.1", optional = true, default-features = false, features = [ "tls" ] }

--- a/examples/async-gpt2-api/Cargo.toml
+++ b/examples/async-gpt2-api/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ort = { path = "../../", features = [ "fetch-models" ] }
+voicevox-ort = { path = "../../", features = [ "fetch-models" ] }
 ndarray = "0.15"
 tokenizers = { version = ">=0.13.4", default-features = false, features = [ "onig" ] }
 rand = "0.8"
@@ -21,5 +21,5 @@ anyhow = "1.0"
 async-stream = "0.3"
 
 [features]
-load-dynamic = [ "ort/load-dynamic" ]
-cuda = [ "ort/cuda" ]
+load-dynamic = [ "voicevox-ort/load-dynamic" ]
+cuda = [ "voicevox-ort/cuda" ]

--- a/examples/custom-ops/Cargo.toml
+++ b/examples/custom-ops/Cargo.toml
@@ -5,9 +5,9 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ort = { path = "../../", features = [ "fetch-models" ] }
+voicevox-ort = { path = "../../", features = [ "fetch-models" ] }
 ndarray = "0.15"
 
 [features]
-load-dynamic = [ "ort/load-dynamic" ]
-cuda = [ "ort/cuda" ]
+load-dynamic = [ "voicevox-ort/load-dynamic" ]
+cuda = [ "voicevox-ort/cuda" ]

--- a/examples/gpt2/Cargo.toml
+++ b/examples/gpt2/Cargo.toml
@@ -5,12 +5,12 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ort = { path = "../../", features = [ "fetch-models" ] }
+voicevox-ort = { path = "../../", features = [ "fetch-models" ] }
 ndarray = "0.15"
 tokenizers = { version = ">=0.13.4", default-features = false, features = [ "onig" ] }
 rand = "0.8"
 tracing-subscriber = { version = "0.3", default-features = false, features = [ "env-filter", "fmt" ] }
 
 [features]
-load-dynamic = [ "ort/load-dynamic" ]
-cuda = [ "ort/cuda" ]
+load-dynamic = [ "voicevox-ort/load-dynamic" ]
+cuda = [ "voicevox-ort/cuda" ]

--- a/examples/model-info/Cargo.toml
+++ b/examples/model-info/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ort = { path = "../../" }
+voicevox-ort = { path = "../../" }
 
 [features]
-load-dynamic = [ "ort/load-dynamic" ]
+load-dynamic = [ "voicevox-ort/load-dynamic" ]

--- a/examples/modnet/Cargo.toml
+++ b/examples/modnet/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ort = { path = "../../" }
+voicevox-ort = { path = "../../" }
 ndarray = "0.15"
 tracing-subscriber = { version = "0.3", default-features = false, features = [ "env-filter", "fmt" ] }
 image = "0.24"
@@ -13,5 +13,5 @@ tracing = "0.1"
 show-image = { version = "0.13", features = [ "image", "raqote" ] }
 
 [features]
-load-dynamic = [ "ort/load-dynamic" ]
-cuda = [ "ort/cuda" ]
+load-dynamic = [ "voicevox-ort/load-dynamic" ]
+cuda = [ "voicevox-ort/cuda" ]

--- a/examples/webassembly/Cargo.toml
+++ b/examples/webassembly/Cargo.toml
@@ -9,7 +9,7 @@ name = "ortwasm"
 crate-type = ["cdylib"]
 
 [dependencies]
-ort = { path = "../../" }
+voicevox-ort = { path = "../../" }
 ndarray = "0.15"
 wasm-bindgen = "0.2.92"
 web-sys = "0.3"
@@ -22,4 +22,4 @@ wasm-bindgen-test = "0.3"
 console_error_panic_hook = "0.1"
 
 [features]
-load-dynamic = [ "ort/load-dynamic" ]
+load-dynamic = [ "voicevox-ort/load-dynamic" ]

--- a/examples/yolov8/Cargo.toml
+++ b/examples/yolov8/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ort = { path = "../../" }
+voicevox-ort = { path = "../../" }
 ndarray = "0.15"
 tracing-subscriber = { version = "0.3", default-features = false, features = [ "env-filter", "fmt" ] }
 image = "0.24"
@@ -15,5 +15,5 @@ ureq = "2.1"
 tracing = "0.1"
 
 [features]
-load-dynamic = [ "ort/load-dynamic" ]
-cuda = [ "ort/cuda" ]
+load-dynamic = [ "voicevox-ort/load-dynamic" ]
+cuda = [ "voicevox-ort/cuda" ]

--- a/ort-sys/Cargo.toml
+++ b/ort-sys/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "ort-sys"
+name = "voicevox-ort-sys"
 description = "Unsafe Rust bindings for ONNX Runtime 1.17 - Optimize and Accelerate Machine Learning Inferencing"
 version = "2.0.0-rc.2"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/pykeio/ort"
+repository = "https://github.com/VOICEVOX/ort"
 documentation = "https://ort.pyke.io/"
 keywords = [ "machine-learning", "ai", "ml" , "sys"]
 categories = [ "algorithms", "mathematics", "science" ]
@@ -13,6 +13,9 @@ authors = [
 	"pyke.io <contact@pyke.io>"
 ]
 include = [ "src/", "dist.txt", "build.rs", "LICENSE-APACHE", "LICENSE-MIT" ]
+
+[lib]
+name = "ort_sys"
 
 [features]
 default = []

--- a/ort-sys/build.rs
+++ b/ort-sys/build.rs
@@ -341,11 +341,11 @@ fn prepare_libort_dir() -> (PathBuf, bool) {
 			} else {
 				"none"
 			};
-			let _ = designator; // ignores the above
+			let _ = designator; // 上記のものを無視する
 			let designator = if cfg!(feature = "directml") {
 				"directml"
 			} else if cfg!(feature = "cuda") {
-				"cu12" // we always use specific version of CUDA, no matter what version of CUDA is installed
+				"cu12" // ビルド環境に何がインストールされていようが、常にCUDA 12を使う
 			} else {
 				"none"
 			};

--- a/ort-sys/build.rs
+++ b/ort-sys/build.rs
@@ -5,8 +5,6 @@ use std::{
 
 const ORT_ENV_SYSTEM_LIB_LOCATION: &str = "ORT_LIB_LOCATION";
 const ORT_ENV_SYSTEM_LIB_PROFILE: &str = "ORT_LIB_PROFILE";
-#[cfg(feature = "download-binaries")]
-const ORT_EXTRACT_DIR: &str = "onnxruntime";
 
 const DIST_TABLE: &str = include_str!("dist.txt");
 
@@ -316,11 +314,38 @@ fn prepare_libort_dir() -> (PathBuf, bool) {
 	} else {
 		#[cfg(feature = "download-binaries")]
 		{
+			#[cfg(any(
+				feature = "tensorrt",
+				feature = "openvino",
+				feature = "onednn",
+				feature = "nnapi",
+				feature = "coreml",
+				feature = "xnnpack",
+				feature = "rocm",
+				feature = "acl",
+				feature = "armnn",
+				feature = "tvm",
+				feature = "migraphx",
+				feature = "rknpu",
+				feature = "vitis",
+				feature = "cann",
+				feature = "qnn"
+			))]
+			compile_error!("unsupported EP");
+
 			let target = env::var("TARGET").unwrap().to_string();
 			let designator = if cfg!(any(feature = "cuda", feature = "tensorrt")) {
 				if lib_exists("cudart64_12.dll") || lib_exists("libcudart.so.12") { "cu12" } else { "cu11" }
 			} else if cfg!(feature = "rocm") {
 				"rocm"
+			} else {
+				"none"
+			};
+			let _ = designator; // ignores the above
+			let designator = if cfg!(feature = "directml") {
+				"directml"
+			} else if cfg!(feature = "cuda") {
+				"cu12" // we always use specific version of CUDA, no matter what version of CUDA is installed
 			} else {
 				"none"
 			};
@@ -351,7 +376,8 @@ fn prepare_libort_dir() -> (PathBuf, bool) {
 				cache_dir = env::var("OUT_DIR").unwrap().into();
 			}
 
-			let lib_dir = cache_dir.join(ORT_EXTRACT_DIR);
+			let ort_extract_dir = prebuilt_url.split('/').last().unwrap().strip_suffix(".tgz").unwrap();
+			let lib_dir = cache_dir.join(ort_extract_dir);
 			if !lib_dir.exists() {
 				let downloaded_file = fetch_file(prebuilt_url);
 				assert!(verify_file(&downloaded_file, prebuilt_hash), "hash of downloaded ONNX Runtime binary does not match!");

--- a/ort-sys/dist.txt
+++ b/ort-sys/dist.txt
@@ -1,19 +1,30 @@
-none	aarch64-apple-darwin	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_static-v1.17.3-aarch64-apple-darwin.tgz	4D3EFABA9B329900B400570FBC1A1F72899149EB3756F9540772701944DC5E49
-none	aarch64-pc-windows-msvc	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_static-v1.17.3-aarch64-pc-windows-msvc.tgz	7BCECBBC15F64C631051C894C5044FB01658F171D7B5D4E9635D7D7F464B8B3E
-none	aarch64-unknown-linux-gnu	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_static-v1.17.3-aarch64-unknown-linux-gnu.tgz	CA36FB040F127C5CAFA081BAC713240EE8C3F4D9F1BD7B789B789FFDD4885F0F
+none	aarch64-apple-darwin	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-osx-arm64-1.17.3.tgz	A11F02FB263783C4202E11E41199D88C510C66F375C092259BC73FA8F25DEB7D
+#none	aarch64-pc-windows-msvc	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_static-v1.17.3-aarch64-pc-windows-msvc.tgz	7BCECBBC15F64C631051C894C5044FB01658F171D7B5D4E9635D7D7F464B8B3E
+none	aarch64-unknown-linux-gnu	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-linux-arm64-1.17.3.tgz	5176F952D3C694825D2408BE37C0D13463631D2B3E956F6BFB84EAEE931726AC
 
-none	x86_64-apple-darwin	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_static-v1.17.3-x86_64-apple-darwin.tgz	938EFA25B53283CA4768E6A779E8BFCA3423468C617FBA458A6E2CA04D2B2E3F
-none	x86_64-pc-windows-msvc	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_static-v1.17.3-x86_64-pc-windows-msvc.tgz	F28C68199A3CDE9AD0D748994894AE2920BDB0A258D3F390E715975FBAB5B4DA
-none	x86_64-unknown-linux-gnu	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_static-v1.17.3-x86_64-unknown-linux-gnu.tgz	6FAF334246A635808FCDAC6D5550C4D56814B1E92CCA5FC0642AF41437BF071F
+none	armv7-unknown-linux-gnueabihf	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-linux-armhf-1.17.3.tgz	F1A0A14FB47B6904EEB38BEE7D550B858788784765684CF7928AA11136354FC7
 
-cu11	x86_64-pc-windows-msvc	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_dylib_cuda11-v1.17.3-x86_64-pc-windows-msvc.tgz	9AE21DECB9BE1270CD850276AAC1AB9C2E2AE978B563B733804F5DF7DACC3BE5
-cu12	x86_64-pc-windows-msvc	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_dylib_cuda12-v1.17.3-x86_64-pc-windows-msvc.tgz	8748005ED6F11A3DA741601FA41D0C6DCCD9FABF704A0853BD3D2CE82FBD49F0
-cu11	x86_64-unknown-linux-gnu	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_dylib_cuda11-v1.17.3-x86_64-unknown-linux-gnu.tgz	D4C264EA6805790D4C8B51D166EF6BD407FB3ECC641B33AEFE77FCD5BF0C6ECA
-cu12	x86_64-unknown-linux-gnu	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_dylib_cuda12-v1.17.3-x86_64-unknown-linux-gnu.tgz	C23A69F709DF91D2BB185D76A29901BD4BE81CD66D85DBCFC5E8BCD851DE9891
-rocm	x86_64-unknown-linux-gnu	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_dylib_rocm-v1.17.3-x86_64-unknown-linux-gnu.tgz	50E39B38484A0676B3D24365149CE9E7760F658B552EFE5A9382AB503D73D7E7
+none	x86_64-apple-darwin	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-osx-x86_64-1.17.3.tgz	14A29904F236B8EF90835422FEA985E6892A94BA8B0E660325025F1DF045C870
+none	x86_64-pc-windows-msvc	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-win-x64-1.17.3.tgz	EB40E58F3BA0BA8D256847429B4511CDAE4C81805891C94F0C58220E3E17CDA8
+none	x86_64-unknown-linux-gnu	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-linux-x64-1.17.3.tgz	65BBCEC997F9854A721B982CD89D11F92D48F122270B9068BCD919E6C13606B5
+
+none	i686-pc-windows-msvc	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-win-x86-1.17.3.tgz	5B4CD789F5FA4936E28A640753EE46E86C4F65792BE7D074E8AC900410D94757
+
+directml	x86_64-pc-windows-msvc	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-win-x64-gpu-1.17.3.tgz	85345B4D7371C9A07C38ABDE853694FB0311EA2E41953DF3CCB052C564BAC8C2
+#cu11	x86_64-pc-windows-msvc	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_dylib_cuda11-v1.17.3-x86_64-pc-windows-msvc.tgz	9AE21DECB9BE1270CD850276AAC1AB9C2E2AE978B563B733804F5DF7DACC3BE5
+cu12	x86_64-pc-windows-msvc	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-win-x64-gpu-1.17.3.tgz	85345B4D7371C9A07C38ABDE853694FB0311EA2E41953DF3CCB052C564BAC8C2
+#cu11	x86_64-unknown-linux-gnu	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_dylib_cuda11-v1.17.3-x86_64-unknown-linux-gnu.tgz	D4C264EA6805790D4C8B51D166EF6BD407FB3ECC641B33AEFE77FCD5BF0C6ECA
+cu12	x86_64-unknown-linux-gnu	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-linux-x64-gpu-1.17.3.tgz	6212F2BD130BAD7F59027DB24DC4DD8510E01FAFE875E04E7863A99B9D8BE400
+#rocm	x86_64-unknown-linux-gnu	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.3/ortrs-msort_dylib_rocm-v1.17.3-x86_64-unknown-linux-gnu.tgz	50E39B38484A0676B3D24365149CE9E7760F658B552EFE5A9382AB503D73D7E7
 
 # todo: update WASM build to 1.17.3
-none	wasm32-wasi	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.1/ortrs-pkort_static_b2-v1.17.1-wasm32-unknown-unknown.tgz	41A5713B37EEE40A0D7608B9E77AEB3E1A5DCE6845496A5F5E65F89A13E45089
-none	wasm32-wasi-preview1	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.1/ortrs-pkort_static_b2-v1.17.1-wasm32-unknown-unknown.tgz	41A5713B37EEE40A0D7608B9E77AEB3E1A5DCE6845496A5F5E65F89A13E45089
-none	wasm32-wasi-preview2	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.1/ortrs-pkort_static_b2-v1.17.1-wasm32-unknown-unknown.tgz	41A5713B37EEE40A0D7608B9E77AEB3E1A5DCE6845496A5F5E65F89A13E45089
-none	wasm32-unknown-unknown	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.1/ortrs-pkort_static_b2-v1.17.1-wasm32-unknown-unknown.tgz	41A5713B37EEE40A0D7608B9E77AEB3E1A5DCE6845496A5F5E65F89A13E45089
+#none	wasm32-wasi	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.1/ortrs-pkort_static_b2-v1.17.1-wasm32-unknown-unknown.tgz	41A5713B37EEE40A0D7608B9E77AEB3E1A5DCE6845496A5F5E65F89A13E45089
+#none	wasm32-wasi-preview1	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.1/ortrs-pkort_static_b2-v1.17.1-wasm32-unknown-unknown.tgz	41A5713B37EEE40A0D7608B9E77AEB3E1A5DCE6845496A5F5E65F89A13E45089
+#none	wasm32-wasi-preview2	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.1/ortrs-pkort_static_b2-v1.17.1-wasm32-unknown-unknown.tgz	41A5713B37EEE40A0D7608B9E77AEB3E1A5DCE6845496A5F5E65F89A13E45089
+#none	wasm32-unknown-unknown	https://parcel.pyke.io/v2/delivery/ortrs/packages/msort-binary/1.17.1/ortrs-pkort_static_b2-v1.17.1-wasm32-unknown-unknown.tgz	41A5713B37EEE40A0D7608B9E77AEB3E1A5DCE6845496A5F5E65F89A13E45089
+
+none	aarch64-linux-android	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-android-arm64-1.17.3.tgz	A8EB02DF2153EF85BDE5C115F6802508077A98348F20FCFE12EC6D1A80DA1B53
+none	x86_64-linux-android	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-android-x64-1.17.3.tgz	DEB8D2687E5B8CFD0D80AF4D1C572248B999C62C6BCBF13108D5F22B4BBC78CE
+none	aarch64-apple-ios	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-ios-arm64-1.17.3.tgz	8687C8E358B65D84D5D2AD4BE9C577227B7D20CD866DF27133185DD0575B5B36
+none	aarch64-apple-ios-sim	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-ios-sim-arm64-1.17.3.tgz	0561A9A1CA0BF3071C5C5CFCA69A1208338C8DDFE924A24A1A26DA618651B4AB
+none	x86_64-apple-ios	https://github.com/VOICEVOX/onnxruntime-builder/releases/download/1.17.3/onnxruntime-ios-sim-x86_64-1.17.3.tgz	B3C253258292E71B7D136E4C0DD0E4598BDCDE98285958020BE86B7014C0E1BA

--- a/ort-sys/src/internal/dirs.rs
+++ b/ort-sys/src/internal/dirs.rs
@@ -1,6 +1,6 @@
 // based on https://github.com/dirs-dev/dirs-sys-rs/blob/main/src/lib.rs
 
-pub const PYKE_ROOT: &str = "ort.pyke.io";
+pub const PYKE_ROOT: &str = "voicevox_ort";
 
 #[cfg(all(target_os = "windows", target_arch = "x86"))]
 macro_rules! win32_extern {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -260,11 +260,12 @@ extern_system_fn! {
 		);
 
 		match severity {
-			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_VERBOSE => tracing::event!(parent: &span, Level::TRACE, "{message}"),
-			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_INFO => tracing::event!(parent: &span, Level::DEBUG, "{message}"),
-			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING => tracing::event!(parent: &span, Level::INFO, "{message}"),
-			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR => tracing::event!(parent: &span, Level::WARN, "{message}"),
-			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_FATAL=> tracing::event!(parent: &span, Level::ERROR, "{message}")
+			// TODO: https://github.com/VOICEVOX/voicevox_project/issues/24 をやる際に、libonnxruntime側で`WARNING`未満のログを遮断する
+			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_VERBOSE | ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_INFO => {}
+			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING => tracing::event!(parent: &span, Level::WARN, "{message}"),
+			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR | ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_FATAL => {
+				tracing::event!(parent: &span, Level::ERROR, "{message}");
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 内容

[v2.0.0-rc.0](https://github.com/pykeio/ort/commit/90b8d3045fe7b483ebea0b7bf0d31a4368bc2e49)を対象に、以下の変更を加えます。

- パッケージ名（crates.ioにアップロードするときの名前）は`voicevox-ort`と`voicevox-ort-sys`とする
    - "crate name"（Rustの実装内での名前）は`ort`と`ort_sys`のまま
- [onnxruntime-builder](https://github.com/VOICEVOX/onnxruntime-builder)でビルドしたlibonnxruntimeを利用する
- 本ライブラリはビルド時に~/.cache/ort.pyke.io（Linuxの場合）にlibonnxruntimeをダウンロードしてそれをリンクするが、それを~/.cache/voicevox\_ortにする
- `directml`と`cuda`以外のExecution Providerをとりあえず拒否
- libonnxruntime本体から流れてくるログの扱いを、VOICEVOXに合わせる
    - `WARNING`未満は握り潰す
    - `WARNING`は`WARN`に、`ERROR`と`FATAL`は`ERROR`に（<https://github.com/VOICEVOX/onnxruntime-rs/pull/16>と同じ）
    - ort自体が出してるログは素通し。問題のないものしかないはず。

## 関連 Issue

- #1
- <https://github.com/VOICEVOX/voicevox_core/pull/725>

## スクリーンショット・動画など

## その他
