### PR TITLE
change: liberate VOICEVOX CORE

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -293,8 +293,8 @@ extern_system_fn! {
 		);
 
 		match severity {
-			// TODO: https://github.com/VOICEVOX/voicevox_project/issues/24 をやる際に、libonnxruntime側で`WARNING`未満のログを遮断する
-			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_VERBOSE | ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_INFO => {}
+			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_VERBOSE => tracing::event!(parent: &span, Level::DEBUG, "{message}"),
+			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_INFO => tracing::event!(parent: &span, Level::INFO, "{message}"),
 			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING => tracing::event!(parent: &span, Level::WARN, "{message}"),
 			ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_ERROR | ort_sys::OrtLoggingLevel::ORT_LOGGING_LEVEL_FATAL => {
 				tracing::event!(parent: &span, Level::ERROR, "{message}");

--- a/src/error.rs
+++ b/src/error.rs
@@ -263,7 +263,9 @@ pub enum Error {
 	#[error("Could't get device ID from memory info: {0}")]
 	GetDeviceId(ErrorInternal),
 	#[error("Training API is not enabled in this build of ONNX Runtime.")]
-	TrainingNotEnabled
+	TrainingNotEnabled,
+	#[error("This ONNX Runtime does not support \"vv-bin\" format (note: load/link `voicevox_onnxruntime` instead of `onnxruntime`)")]
+	VvBinNotSupported
 }
 
 impl Error {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -446,7 +446,11 @@ impl SessionBuilder {
 		Ok(session)
 	}
 
+	#[cfg(feature = "__init-for-voicevox")]
 	pub fn commit_from_vv_bin(self, bin: &[u8]) -> Result<Session> {
+		if !crate::EnvHandle::get().expect("should be present").is_voicevox_onnxruntime {
+			return Err(Error::VvBinNotSupported);
+		}
 		ortsys![unsafe AddSessionConfigEntry(self.session_options_ptr.as_ptr(), c"session.use_vv_bin".as_ptr(), c"1".as_ptr())];
 		self.commit_from_memory(bin)
 	}

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -445,6 +445,11 @@ impl SessionBuilder {
 		};
 		Ok(session)
 	}
+
+	pub fn commit_from_vv_bin(self, bin: &[u8]) -> Result<Session> {
+		ortsys![unsafe AddSessionConfigEntry(self.session_options_ptr.as_ptr(), c"session.decrypt_vv_model".as_ptr(), c"1".as_ptr())];
+		self.commit_from_memory(bin)
+	}
 }
 
 /// ONNX Runtime provides various graph optimizations to improve performance. Graph optimizations are essentially

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -447,7 +447,7 @@ impl SessionBuilder {
 	}
 
 	pub fn commit_from_vv_bin(self, bin: &[u8]) -> Result<Session> {
-		ortsys![unsafe AddSessionConfigEntry(self.session_options_ptr.as_ptr(), c"session.decrypt_vv_model".as_ptr(), c"1".as_ptr())];
+		ortsys![unsafe AddSessionConfigEntry(self.session_options_ptr.as_ptr(), c"session.use_vv_bin".as_ptr(), c"1".as_ptr())];
 		self.commit_from_memory(bin)
 	}
 }


### PR DESCRIPTION
## 内容

1. `SessionBuilder::commit_from_vv_bin`を追加し、暗号化対応ONNX Runtimeに暗号化ONNXを渡せるようにします。
2. `INFO`以下のログをせき止めていたのをやめます。

## 関連 Issue

ref VOICEVOX/voicevox_project#24

## スクリーンショット・動画など

## その他
