### PR TITLE
fix: `cfg(not(feature = "download-binaries"))`のビルドを直す

### DIFF
--- a/ort-sys/src/internal/mod.rs
+++ b/ort-sys/src/internal/mod.rs
@@ -1,3 +1,4 @@
 pub mod dirs;
 
+#[cfg(feature = "download-binaries")]
 include!(concat!(env!("OUT_DIR"), "/downloaded_version.rs"));


### PR DESCRIPTION
## 内容

`cfg(not(feature = "download-binaries"))`でのビルドが壊れてたので直します。

```console
error: couldn't read /home/ryo/src/github.com/VOICEVOX/voicevox_core/main/target/release/build/voicevox-ort-sys-054fe364665b3fd2/out/downloaded_version.rs: No such file or directory (os error 2)
 --> /home/ryo/.cargo/git/checkouts/ort-d0492e4da5dd1ef1/8627833/ort-sys/src/internal/mod.rs:3:1
  |
3 | include!(concat!(env!("OUT_DIR"), "/downloaded_version.rs"));
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `voicevox-ort-sys` (lib) due to 1 previous error
```

現段階では何かの支障になっているわけではないのですが、意図に反して壊れている状態ではあるので一応。
(「現段階では」というのは、`voicevox_core/load-onnxruntime`でもlibonnxruntimeが自動ダウンロードされるのは無駄、という判断もできそうなため)

## 関連 Issue

## スクリーンショット・動画など

## その他
