### PR TITLE
fix: cherry pick v2.0.0-rc.5's `2db63f4`

### DIFF
--- a/src/session/async.rs
+++ b/src/session/async.rs
@@ -153,6 +153,7 @@ crate::extern_system_fn! {
 		if let Err(e) = crate::error::status_to_result(status) {
 			ctx.inner.emplace_value(Err(Error::SessionRun(e)));
 			ctx.inner.wake();
+			return;
 		}
 
 		let outputs: Vec<Value> = ctx


### PR DESCRIPTION
## 内容

## 関連 Issue

Refs: VOICEVOX/voicevox_core#687, <https://github.com/pykeio/ort/commit/2db63f419531b0f418d5f9934d7037f9e46c1b5c>

## スクリーンショット・動画など

Without this:

![image](https://github.com/user-attachments/assets/b9612065-6628-4fa0-9611-e20f9fb9e330)

## その他
