### PR TITLE
fix: cherry pick v2.0.0-rc.5's `08aaa0f`

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -145,7 +145,10 @@ pub enum AllocationDevice {
 	HIP,
 	HIPPinned,
 	OpenVINOCPU,
-	OpenVINOGPU
+	OpenVINOGPU,
+	// these aren't defined in allocator.h and are instead scattered all over. fun!
+	DirectMLCPU,
+	TVM
 }
 
 impl AllocationDevice {
@@ -157,17 +160,19 @@ impl AllocationDevice {
 			Self::CANN => "Cann",
 			Self::CANNPinned => "CannPinned",
 			Self::DirectML => "Dml",
+			Self::DirectMLCPU => "DML CPU", // yes, caps & space
 			Self::HIP => "Hip",
 			Self::HIPPinned => "HipPinned",
 			Self::OpenVINOCPU => "OpenVINO_CPU",
-			Self::OpenVINOGPU => "OpenVINO_GPU"
+			Self::OpenVINOGPU => "OpenVINO_GPU",
+			Self::TVM => "TVM"
 		}
 	}
 
 	/// Returns `true` if this memory is accessible by the CPU; meaning that, if a value were allocated on this device,
 	/// it could be extracted to an `ndarray` or slice.
 	pub fn is_cpu_accessible(&self) -> bool {
-		matches!(self, Self::CPU | Self::CUDAPinned | Self::CANNPinned | Self::HIPPinned | Self::OpenVINOCPU)
+		matches!(self, Self::CPU | Self::CUDAPinned | Self::CANNPinned | Self::HIPPinned | Self::OpenVINOCPU | Self::DirectMLCPU | Self::TVM)
 	}
 }
 
@@ -182,10 +187,12 @@ impl TryFrom<String> for AllocationDevice {
 			"Cann" => Ok(AllocationDevice::CANN),
 			"CannPinned" => Ok(AllocationDevice::CANNPinned),
 			"Dml" => Ok(AllocationDevice::DirectML),
+			"DML CPU" => Ok(AllocationDevice::DirectMLCPU),
 			"Hip" => Ok(AllocationDevice::HIP),
 			"HipPinned" => Ok(AllocationDevice::HIPPinned),
 			"OpenVINO_CPU" => Ok(AllocationDevice::OpenVINOCPU),
 			"OpenVINO_GPU" => Ok(AllocationDevice::OpenVINOGPU),
+			"TVM" => Ok(AllocationDevice::TVM),
 			_ => Err(value)
 		}
 	}


### PR DESCRIPTION
## 内容

<https://github.com/pykeio/ort/commit/08aaa0ffabf597eb97514180460de65bd1bf9938>と同様、 pykeio/ort#253 を解決する。

VOICEVOXの場合推論時に次の警告が出る状態なので、おそらくそれで`DML CPU`が必要とされると推測します。

```console
[WARNING] ort.environment: Some nodes were not assigned to the preferred execution providers which may or may not have an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.
[WARNING] ort.environment: Some nodes were not assigned to the preferred execution providers which may or may not have an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.
```

ちなみにCUDAでも同じような警告が出ました ~~（ただしこちらは2回ではなく1回）~~ 。

```console
[WARNING] ort.environment: Some nodes were not assigned to the preferred execution providers which may or may not have an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.
[WARNING] ort.environment: 9 Memcpy nodes are added to the graph torch_jit for CUDAExecutionProvider. It might have negative impact on performance (including unable to run CUDA graph). Set session_options.log_severity_level=1 to see the detail logs before this message.
[WARNING] ort.environment: Some nodes were not assigned to the preferred execution providers which may or may not have an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.
```

## 関連 Issue

## スクリーンショット・動画など

## その他
